### PR TITLE
docs: fix typos

### DIFF
--- a/docs/guides/actors.md
+++ b/docs/guides/actors.md
@@ -152,7 +152,7 @@ const machine = createMachine({
 ```
 
 ::: tip
-If you provide an unique `name` argument to `spawn(...)`, you can reference it in the target expression:
+If you provide a unique `name` argument to `spawn(...)`, you can reference it in the target expression:
 
 ```js
 const loginMachine = createMachine({

--- a/docs/guides/history.md
+++ b/docs/guides/history.md
@@ -1,6 +1,6 @@
 # History
 
-A history [state node](./statenodes.md) is a special kind of state node that, when reached, tells the machine to go to the last state value of that region. There's two types of history states:
+A history [state node](./statenodes.md) is a special kind of state node that, when reached, tells the machine to go to the last state value of that region. There are two types of history states:
 
 - `'shallow'`, which specifies only the top-level history value, or
 - `'deep'`, which specifies the top-level and all child-level history values.

--- a/docs/guides/internal.md
+++ b/docs/guides/internal.md
@@ -1,3 +1,3 @@
 # Internal Transitions
 
-See [the **Internal Transtions** docs](./transitions.md#internal-transitions).
+See [the **Internal Transitions** docs](./transitions.md#internal-transitions).

--- a/docs/guides/transitions.md
+++ b/docs/guides/transitions.md
@@ -402,13 +402,13 @@ gameService.send('AWARD_POINTS');
 ::: warning
 
 It is possible to create infinite loops if eventless transitions are misused.
-Eventless transitions should be defined either with `target`, `cond` + `target`, `cond` + `actions`, or `cond` + `target` + `actions`. Target, if declared, should be different than the current state node. Eventless transitions with no `target` nor `cond` will cause an infinite loop. Transitions with `cond` and `actions` may run into an infinite loop if its `cond` guard keeps returning `true`.
+Eventless transitions should be defined either with `target`, `cond` + `target`, `cond` + `actions`, or `cond` + `target` + `actions`. Target, if declared, should be different from the current state node. Eventless transitions with no `target` nor `cond` will cause an infinite loop. Transitions with `cond` and `actions` may run into an infinite loop if its `cond` guard keeps returning `true`.
 
 :::
 
 ::: tip
 
-When eventless transitions are checked, their guards are evaluated repeatedly until all of them return `false` or a transition with `target` is validated. Every time some guard evaluates to `true` during this process, its associated actions are going to be executed once. Thus it is possible that during a single microtask, some transitions without targets are executed multiple times.
+When eventless transitions are checked, their guards are evaluated repeatedly until all of them return `false` or a transition with `target` is validated. Every time some guard evaluates to `true` during this process, its associated actions are going to be executed once. Thus, it is possible that during a single microtask, some transitions without targets are executed multiple times.
 This contrasts with common transitions, where always a maximum of one transition can be taken.
 
 :::


### PR DESCRIPTION
This just fixes some types or style in the docs.